### PR TITLE
Return if robot hears '++' with no username

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -13,6 +13,7 @@ module.exports = (robot) ->
   robot.hear /^@?(.*?)(\+\+|--)\s*$/, (response) ->
     thisUser = response.message.user
     targetToken = response.match[1].trim()
+    return if not targetToken
     targetUser = userForToken targetToken, response
     return if not targetUser
     return response.send "Hey, you can't give yourself karma!" if thisUser is targetUser


### PR DESCRIPTION
Right now if someone says '++' the robot hears it and does a lookup on '', which triggers the response:

> Be more specific, I know 277 people named like that: {{ long list of 277 usernames, pinging everyone in the company }}

This change exits early if no username was heard. (Alternatively you could remove the `?` from the regex for that robot.hear, but I wasn't sure if that had any other effects?)
