### PR TITLE
Account for Slack username auto-completion

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -10,7 +10,7 @@
 
 module.exports = (robot) ->
 
-  robot.hear /^@?(.*?)(\+\+|--)\s*$/, (response) ->
+  robot.hear /^@?(.*?)[: ]*(\+\+|--)\s*$/, (response) ->
     thisUser = response.message.user
     targetToken = response.match[1].trim()
     return if not targetToken


### PR DESCRIPTION
Slack adds a colon and space after a username when it auto-completes. This change lets the bot take action on strings like "@aliso: ++" which will happen often when a team uses Slack.
